### PR TITLE
Make the user and group overrideable

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -15,8 +15,8 @@
 #
 RUN_DIR=$(cd $(dirname "$0") && pwd)
 APPLICATION_NAME="murano applications packages"
-DAEMON_USER="murano"
-DAEMON_GROUP="murano"
+DAEMON_USER=${DAEMON_USER:-"murano"}
+DAEMON_GROUP=${DAEMON_GROUP:-"murano"}
 DAEMON_CONF="/etc/murano/murano.conf"
 MANAGE_CMD=$(which murano-manage)
 #


### PR DESCRIPTION
I want to call this from within vagrant and the user is "vagrant"
so with this change I can do the following:

(sudo DAEMON_USER=vagrant DAEMON_GROUP=vagrant ./setup.sh install)

Signed-off-by: Angus Salkeld asalkeld@mirantis.com
